### PR TITLE
Task #7, Configured auto-escaping for svg template

### DIFF
--- a/src/main/java/org/gahan/MyMojo.java
+++ b/src/main/java/org/gahan/MyMojo.java
@@ -1,5 +1,9 @@
 package org.gahan;
 
+import freemarker.cache.ConditionalTemplateConfigurationFactory;
+import freemarker.cache.PathGlobMatcher;
+import freemarker.core.TemplateConfiguration;
+import freemarker.core.XMLOutputFormat;
 import freemarker.template.Configuration;
 import freemarker.template.Template;
 import freemarker.template.TemplateException;
@@ -65,6 +69,12 @@ public class MyMojo extends AbstractMojo {
     configuration.setDefaultEncoding("UTF-8");
     configuration.setLocale(Locale.US);
     configuration.setTemplateExceptionHandler(TemplateExceptionHandler.RETHROW_HANDLER);
+
+    TemplateConfiguration tcSvg = new TemplateConfiguration();
+    tcSvg.setOutputFormat(XMLOutputFormat.INSTANCE);
+
+    configuration.setTemplateConfigurations(
+        new ConditionalTemplateConfigurationFactory(new PathGlobMatcher("**/svg-*"), tcSvg));
 
     // load the template
     Template template = configuration.getTemplate("svg-badge-template.ftl");


### PR DESCRIPTION
Configure `freemarker` [auto-escaping](https://freemarker.apache.org/docs/dgui_misc_autoescaping.html) for svg templates.

Fix encoding issues when badge labels contain 'invalid' characters.

```sh
mvn -Dbadge.badgeLabel='<x>' org.gahan:jacoco-cov-badge-maven-plugin:1.0-SNAPSHOT:badge
```